### PR TITLE
Fix /usr/lib64 install error

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -16,6 +16,7 @@ arch=('x86_64')
 build() {
   cd $pkgname-$pkgver
   cmake -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_INSTALL_LIBDIR=lib \
         -DBUILD_STATIC_LIBS=OFF .
   make
 }


### PR DESCRIPTION
On Arch Linux we must install to /usr/lib and not /usr/lib64.

I fixed the bug using the same workaround as eigen:
https://git.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/eigen